### PR TITLE
Hold gesture

### DIFF
--- a/lib/filter.js
+++ b/lib/filter.js
@@ -15,7 +15,9 @@ Filter.prototype.on = function(type, optionsOrCallback, callback) {
     options = {};
     callback = optionsOrCallback;
   }
-  this._filters.push(new filterType(options, callback));
+  var filter = new filterType(options, callback);
+  filter.id = this._filters.length;
+  this._filters.push(filter);
   return this;
 }
 
@@ -35,7 +37,8 @@ Filter.prototype.drinkFromFirehose = function(controller) {
 // what types go to what filter objects
 // exposed publicly so that you can add additional types
 Filter.types = {
-  "gesture": require('./filter/gesture.js')
+  gesture: require('./filter/gesture.js'),
+  hold: require('./filter/hold.js')
 }
 
 module.exports = Filter;

--- a/lib/filter/hold.js
+++ b/lib/filter/hold.js
@@ -1,0 +1,7 @@
+
+var HoldFilter = function(options, callback) {
+  this.callback = callback;
+  this._processOptions(options);
+}
+
+

--- a/lib/filter/hold.js
+++ b/lib/filter/hold.js
@@ -1,4 +1,5 @@
-var HoldFrameAnalyzer = require("./hold/frame_analyzer.js");
+var HoldFrameAnalyzer = require("./hold/frame_analyzer");
+var TrackedHolds = require("./hold/tracked_holds");
 
 var HoldFilter = function(options, callback) {
   if (!callback) { throw new Error("Hold filter requires a callback!") }
@@ -11,11 +12,15 @@ HoldFilter.prototype._processOptions = function(options) {
 
   options.maxDistance = options.maxDistance || 20;
   options.maxVelocity = options.maxVelocity || 60;
+  // minimum duration by default 1 second
+  options.minDuration = typeof(options.minDuration) == "undefined" ? 1000 : options.minDuration;
 }
 
 HoldFilter.prototype.process = function(frame) {
   var filteringCallback = function(gesture) {
     if (this._checkCriteria(gesture)) {
+      // if this is a hold that just hit its duration limit, override the state
+      // to update
       this.callback(gesture);
     }
   }.bind(this);
@@ -27,7 +32,6 @@ HoldFilter.prototype._checkCriteria = function(gesture) {
   // check to see if it's the right gesture in the right state (if applicable)
   if (this.options.state && gesture.state != this.options.state) { return false };
 
-  // later we can have checks for criteria like duration
   return true;
 }
 

--- a/lib/filter/hold.js
+++ b/lib/filter/hold.js
@@ -1,7 +1,34 @@
+var HoldFrameAnalyzer = require("./hold/frame_analyzer.js");
 
 var HoldFilter = function(options, callback) {
+  if (!callback) { throw new Error("Hold filter requires a callback!") }
   this.callback = callback;
   this._processOptions(options);
 }
 
+HoldFilter.prototype._processOptions = function(options) {
+  this.options = options || {};
 
+  options.maxDistance = options.maxDistance || 20;
+  options.maxVelocity = options.maxVelocity || 60;
+}
+
+HoldFilter.prototype.process = function(frame) {
+  var filteringCallback = function(gesture) {
+    if (this._checkCriteria(gesture)) {
+      this.callback(gesture);
+    }
+  }.bind(this);
+
+  new HoldFrameAnalyzer(frame, this.options, filteringCallback).process();
+}
+
+HoldFilter.prototype._checkCriteria = function(gesture) {
+  // check to see if it's the right gesture in the right state (if applicable)
+  if (this.options.state && gesture.state != this.options.state) { return false };
+
+  // later we can have checks for criteria like duration
+  return true;
+}
+
+module.exports = HoldFilter;

--- a/lib/filter/hold/frame_analyzer.js
+++ b/lib/filter/hold/frame_analyzer.js
@@ -21,7 +21,12 @@ FrameAnalyzer.prototype.process = function() {
       passing = passing && this[checkFnName](hand);
     }
     if (passing) {
-      this.callback(this._processActiveHold(hand));
+      gesture = this._processActiveHold(hand);
+      // we may not always publish gestures even if they're active
+      // for instance, if they're below the minimum duration
+      if (gesture) {
+        this.callback(gesture);
+      }
     }
     else if (TrackedHolds.storedHold(hand.id)) {
       // if we don't have a valid hold, we only want to fire a stopped event
@@ -80,13 +85,23 @@ FrameAnalyzer.prototype._processStoppedHold = function(handId, reason) {
 }
 
 FrameAnalyzer.prototype._processActiveHold = function(hand) {
-  var newHold = !TrackedHolds.storedHold(hand.id);
-  var state = newHold ? "start" : "update";
-  if (newHold) {
-    TrackedHolds.storeHold(hand);
+  // first, make sure we're tracking this
+  var hold = TrackedHolds.storedHold(hand.id);
+  var minDuration = this.options.minDuration;
+  if (!hold) {
+    hold = TrackedHolds.storeHold(hand);
   }
 
-  return this._constructGesture(hand.id, state);
+  // now, see if we should publish an event
+  if (!minDuration || new Date() - hold.timestamp > minDuration) {
+    state = hold.published ? "update" : "start";
+    hold.published = true;
+    return this._constructGesture(hand.id, state);
+  }
+  else {
+    // don't publish this yet
+    return null;
+  }
 }
 
 FrameAnalyzer.prototype._constructGesture = function(handId, state) {
@@ -94,12 +109,6 @@ FrameAnalyzer.prototype._constructGesture = function(handId, state) {
   // but hand might not be (if the hand has vanished)
   var storedHold = TrackedHolds.storedHold(handId);
   var hand = this.frame.hand(handId);
-
-  // if (state != "update") {
-  //   console.log("Hand: ", hand.palmPosition, hand.palmVelocity);
-  // }
-  // else {
-  // console.log("update")}
 
   return {
     type: "hold",

--- a/lib/filter/hold/frame_analyzer.js
+++ b/lib/filter/hold/frame_analyzer.js
@@ -1,0 +1,117 @@
+var TrackedHolds = require("./tracked_holds.js")
+
+// a class for analyzing a specific frame
+// being able to store and reference the frame in object instances is quite
+// useful
+var FrameAnalyzer = function(frame, options, callback) {
+  this.frame = frame;
+  this.options = options;
+  this.callback = callback;
+}
+
+FrameAnalyzer.prototype.process = function() {
+  var hand, gesture, passing, checkFnName;
+
+  this._removeVanishedAppendages();
+  for (var i = 0; i < this.frame.hands.length; i++) {
+    hand = this.frame.hands[i];
+    passing = true;
+    for (var i = 0; i < this._holdChecks.length && passing; i++) {
+      checkFnName = this._holdChecks[i];
+      passing = passing && this[checkFnName](hand);
+    }
+    if (passing) {
+      this.callback(this._processActiveHold(hand));
+    }
+    else if (TrackedHolds.storedHold(hand.id)) {
+      // if we don't have a valid hold, we only want to fire a stopped event
+      // if there's actually a hold being tracked
+      // otherwise you'd fire events during non-hold movement
+      this.callback(this._processStoppedHold(hand.id));
+    }
+  }
+}
+
+FrameAnalyzer.prototype._holdChecks = ["_checkVelocity", "_checkPosition"];
+
+FrameAnalyzer.prototype._checkVelocity = function(hand) {
+  var velocity = hand.palmVelocity;
+  for (var i = 0; i < velocity.length; i++) {
+    if (Math.abs(velocity[i]) > this.options.maxVelocity) {
+      return false;
+    }
+  }
+  return true;
+}
+
+FrameAnalyzer.prototype._checkPosition = function(hand) {
+  var position = hand.palmPosition, distance;
+  // sometime we get hands without position?!
+  if (!position) { return false; }
+  var originalData = TrackedHolds.storedHold(hand.id);
+  if (!originalData) {
+    // no position check for new gestures, obviously
+    return true;
+  }
+  var originalPosition = originalData.hand.palmPosition;
+
+  for (var i = 0; i < position.length; i++) {
+    distance = position[i] - originalPosition[i];
+    if (Math.abs(distance) > this.options.maxDistance) {
+      return false;
+    }
+  }
+  return true;
+}
+
+FrameAnalyzer.prototype._removeVanishedAppendages = function() {
+  for (var id in TrackedHolds.holds("hand")) {
+    if (!this.frame.hand(id)) {
+      var stopGesture = this._processStoppedHold(id, "vanished");
+      this.callback(stopGesture)
+    }
+  }
+}
+
+FrameAnalyzer.prototype._processStoppedHold = function(handId, reason) {
+  var gesture = this._constructGesture(handId, "stop");
+  TrackedHolds.flushHold(handId);
+  return gesture;
+}
+
+FrameAnalyzer.prototype._processActiveHold = function(hand) {
+  var newHold = !TrackedHolds.storedHold(hand.id);
+  var state = newHold ? "start" : "update";
+  if (newHold) {
+    TrackedHolds.storeHold(hand);
+  }
+
+  return this._constructGesture(hand.id, state);
+}
+
+FrameAnalyzer.prototype._constructGesture = function(handId, state) {
+  // storedHold should always be available,
+  // but hand might not be (if the hand has vanished)
+  var storedHold = TrackedHolds.storedHold(handId);
+  var hand = this.frame.hand(handId);
+
+  // if (state != "update") {
+  //   console.log("Hand: ", hand.palmPosition, hand.palmVelocity);
+  // }
+  // else {
+  // console.log("update")}
+
+  return {
+    type: "hold",
+    state: state,
+    handIds: [handId],
+    pointableIds: [],
+    position: hand ? hand.palmPosition : null,
+    startPosition: storedHold.hand.palmPosition,
+    duration: new Date() - storedHold.timestamp,
+    // id is, for now, useless -- later we'll have to wrap Frame.gesture()
+    id: Math.round(Math.random() * 100000)
+  }
+}
+
+module.exports = FrameAnalyzer;

--- a/lib/filter/hold/tracked_holds.js
+++ b/lib/filter/hold/tracked_holds.js
@@ -20,8 +20,11 @@ TrackedHolds.storeHold = function(hand) {
   // track the initial information for the hand
   this.hands[hand.id] = {
     hand: handCopy,
-    timestamp: new Date()
+    timestamp: new Date(),
+    published: false
   };
+
+  return this.hands[hand.id];
 }
 
 TrackedHolds.flushHold = function(id) {

--- a/lib/filter/hold/tracked_holds.js
+++ b/lib/filter/hold/tracked_holds.js
@@ -1,0 +1,35 @@
+var TrackedHolds = {
+  hands: {}
+}
+
+TrackedHolds.holds = function() {
+  return this.hands;
+}
+
+TrackedHolds.storedHold = function(id) {
+  return this.hands[id];
+}
+
+TrackedHolds.storeHold = function(hand) {
+  // there's an easier way to do this but I'm on an airplane
+  var handCopy = {};
+  for (var attr in hand) {
+    handCopy[attr] = hand[attr];
+  }
+
+  // track the initial information for the hand
+  this.hands[hand.id] = {
+    hand: handCopy,
+    timestamp: new Date()
+  };
+}
+
+TrackedHolds.flushHold = function(id) {
+  delete this.hands[id];
+}
+
+TrackedHolds.flushAll = function() {
+  this.hands = {};
+}
+
+module.exports = TrackedHolds;

--- a/readme.md
+++ b/readme.md
@@ -57,12 +57,13 @@ Features:
 
 * _Gesture analysis_: detect primary direction of movement
 * _Gesture filter_: eliminate ghost/duplicate events
+* _Hold gesture_: track a hand held in place (useful as a trigger, for
+instance)
 
 
 Planned:
 --------
 
-* _Hold filter_: filter for holding a hand or finger in place
 * _Slow swipe_: track continuous movement in a single direction too slow for
 the built-in Swipe gesture (for instance, controlling the volume by moving your
 hand up and down)

--- a/test/filter/gesture_test.js
+++ b/test/filter/gesture_test.js
@@ -17,7 +17,6 @@ describe("Gesture Filter", function() {
     filter = new GestureFilter(options, callback);
   })
 
-
   describe("constructor", function() {
     it("sets the options provided", function() {
       var options = {type: "circle", duplicateWindow: 2, a: 3};

--- a/test/filter/hold_test.js
+++ b/test/filter/hold_test.js
@@ -1,8 +1,8 @@
 var expect = require('expect.js');
 var sinon = require('sinon')
 var BlueGel = require("../../lib/bluegel")
-var HoldFilter = BlueGel.Filter.types.gesture;
-var Analysis = BlueGel.Analysis;
+var HoldFilter = BlueGel.Filter.types.hold;
+var TrackedHolds = require("../../lib/filter/hold/tracked_holds");
 
 var callback = function(gesture) {
   return gesture;
@@ -12,22 +12,28 @@ describe("Hold filter", function() {
   var options, callback, filter, frame, hand, clock;
 
   beforeEach(function() {
-    options = {
-      type: "hold",
-      maximumVelocity: 6,
-      maximumMovement: 8
-    };
+    options = {};
 
     callback = sinon.spy();
     filter = new HoldFilter(options, callback);
     hand = {
       id: Math.random(),
-      position: [1, 2, 3],
+      palmPosition: [1, 2, 3],
       palmVelocity: [0.5, 0.3, 0.4]
     }
 
     frame = {
-      hands: [hand]
+      hands: [hand],
+      hand: function(handId) {
+        var hand;
+        for (var i = 0; i < this.hands.length; i++) {
+          hand = this.hands[i];
+          if (handId == hand.id) {
+            return hand;
+          }
+        }
+        return null;
+      }
     }
 
     clock = sinon.useFakeTimers();
@@ -35,18 +41,110 @@ describe("Hold filter", function() {
 
   afterEach(function() {
     clock.restore();
+    TrackedHolds.flushAll();
+  })
+
+  describe("constructor", function() {
+    it("sets the options provided", function() {
+      var options = {maxVelocity: 3, a: 3};
+      var filter = new HoldFilter(options, callback);
+      expect(filter.options).to.have.property("a", 3);
+      expect(filter.options).to.have.property("maxVelocity", 3);
+    })
+
+    it("defines the maxVelocity if not provided", function() {
+      expect(filter.options).to.have.property("maxVelocity");
+    })
+
+    it("defines the maxDistance if not provided", function() {
+      expect(filter.options).to.have.property("maxDistance");
+    })
+
+    it("saves the callback", function() {
+      expect(filter.callback).to.equal(callback);
+    })
+
+    it("throws an exception if no callback is provided", function() {
+      expect(function() { new HoldFilter(options) }).to.throwException();
+    })
   })
 
   describe("process", function() {
-    describe("if all requirements pass", function() {
+    describe("filtering on state", function() {
+      describe("for start", function() {
+        it("doesn't call the callback if it asks for update", function() {
+          options.state = "update";
+          filter = new HoldFilter(options, callback);
+          filter.process(frame);
+          expect(callback.called).to.be(false)
+        })
+
+        it("doesn't call the callback if it asks for stop", function() {
+          options.state = "stop";
+          filter = new HoldFilter(options, callback);
+          filter.process(frame);
+          expect(callback.called).to.be(false)
+        })
+      })
+
+      describe("for update", function() {
+        var callCount;
+
+        beforeEach(function() {
+          filter.process(frame);
+          callCount = callback.callCount;
+        })
+
+        it("doesn't call the callback if it asks for start", function() {
+          options.state = "start";
+          filter = new HoldFilter(options, callback);
+          filter.process(frame);
+          expect(callback.callCount).to.equal(callCount);
+        })
+
+        it("doesn't call the callback if it asks for stop", function() {
+          options.state = "stop";
+          filter = new HoldFilter(options, callback);
+          filter.process(frame);
+          expect(callback.callCount).to.equal(callCount);
+        })
+      })
+
+      describe("for stop", function() {
+        var callCount;
+
+        beforeEach(function() {
+          filter.process(frame);
+          hand.palmVelocity = [1000, 0, 0]
+          callCount = callback.callCount;
+        })
+
+        it("doesn't call the callback if it asks for start", function() {
+          options.state = "start";
+          filter = new HoldFilter(options, callback);
+          filter.process(frame);
+          expect(callback.callCount).to.equal(callCount);
+        })
+
+        it("doesn't call the callback if it asks for update", function() {
+          options.state = "update";
+          filter = new HoldFilter(options, callback);
+          filter.process(frame);
+          expect(callback.callCount).to.equal(callCount);
+        })
+      })
+    })
+
+    describe("if all requirements for a hold pass", function() {
       beforeEach(function() {
         filter.process(frame);
       })
 
       describe("the callback", function() {
         var gesture;
+
         beforeEach(function() {
-          gesture = callback.firstArgs[0];
+          gesture = callback.firstCall.args[0];
         })
 
         it("calls the callback if all requirements pass", function() {
@@ -54,11 +152,11 @@ describe("Hold filter", function() {
         })
 
         it("includes the hand of the gesture", function() {
-          expect(gesture).to.have.property("handIds", [hand]);
+          expect(gesture.handIds).to.eql([hand.id]);
         })
 
         it("includes no fingers", function() {
-          expect(gesture).to.have.property("pointableIds", []);
+          expect(gesture.pointableIds).to.eql([]);
         })
 
         it("sets the type appropriately", function() {
@@ -81,26 +179,24 @@ describe("Hold filter", function() {
       })
 
       describe("if there's already a hold", function() {
-        beforeEach(function() {
-          filter.process(frame);
-        })
-
         it("sends an update", function() {
           filter.process(frame);
           expect(callback.callCount).to.be(2);
+          var gesture = callback.lastCall.args[0];
           expect(gesture.state).to.equal("update");
         })
 
         it("updates the position", function() {
-          var originalLocation = frame.position;
-          frame.position = [
+          var originalLocation = hand.palmPosition;
+          hand.palmPosition = [
             originalLocation[0] + 0.1,
             originalLocation[1] + 0.1,
             originalLocation[2] + 0.1
           ];
+          filter.process(frame);
           var gesture = callback.lastCall.args[0];
           expect(gesture.startPosition).to.eql(originalLocation);
-          expect(gesture.position).to.eql(frame.position);
+          expect(gesture.position).to.eql(hand.palmPosition);
         })
 
         it("updates the duration", function() {
@@ -116,7 +212,7 @@ describe("Hold filter", function() {
     describe("if velocity fails", function() {
       describe("if no hold is being tracked", function() {
         beforeEach(function() {
-          frame.velocity = [100, 100, 100];
+          hand.palmVelocity = [100, 100, 100];
         })
 
         it("doesn't start a gesture if there is none", function() {
@@ -125,7 +221,7 @@ describe("Hold filter", function() {
         })
 
         it("also catches negative velocities", function() {
-          frame.velocity = [-100, 0, 0];
+          hand.palmVelocity = [-100, 0, 0];
           filter.process(frame);
           expect(callback.called).to.be(false);
         })
@@ -133,8 +229,8 @@ describe("Hold filter", function() {
 
       describe("if a hold is being tracked", function() {
         beforeEach(function() {
-          frame.process(frame);
-          frame.velocity = [100, 100, 100];
+          filter.process(frame);
+          hand.palmVelocity = [100, 100, 100];
         })
 
         it("fires a stopped event the hold was started", function() {
@@ -144,54 +240,64 @@ describe("Hold filter", function() {
 
         it("clears the tracked hold", function() {
           filter.process(frame);
-          frame.velocity = [0, 0, 0];
+          hand.palmVelocity = [0, 0, 0];
           // see if after a hold stop, we trigger a hold start, not an update
           filter.process(frame);
-          expect(callback.lastCall.args.state).to.equal("start");
+          expect(callback.lastCall.args[0].state).to.equal("start");
         })
       })
     })
 
     describe("if position fails", function() {
-      describe("if no hold is being tracked", function() {
-        beforeEach(function() {
-          frame.position = [100, 100, 100];
-        })
-
-        it("doesn't start a gesture if there is none", function() {
-          filter.process(frame);
-          expect(callback.called).to.be(false);
-        })
-
-        it("also catches negative positions", function() {
-          frame.velocity = [-100, 0, 0];
-          filter.process(frame);
-          expect(callback.called).to.be(false);
-        })
-      })
-
+      // position can only fail if there's an existing hold
       describe("if a hold is being tracked", function() {
         beforeEach(function() {
-          frame.process(frame);
-          frame.position = [100, 100, 100];
+          filter.process(frame);
+          hand.palmPosition = [100, 100, 100];
+          filter.process(frame);
         })
 
         it("fires a stopped event the hold was started", function() {
-          filter.process(frame);
           expect(callback.lastCall.args[0].state).to.equal("stop");
         })
 
         it("clears the tracked hold", function() {
-          filter.process(frame);
           // see if after a hold stop, we trigger a hold start at the new
           // position, not an update
           filter.process(frame);
-          var gesture = callback.lastCall.args;
+          var gesture = callback.lastCall.args[0];
           expect(gesture.state).to.equal("start");
-          expect(gesture.position).to.eql(frame.position);
+          expect(gesture.position).to.eql(hand.palmPosition);
+        })
+      })
+    })
+
+    describe("if a hand goes missing", function() {
+      describe("if a hold is being tracked", function() {
+        beforeEach(function() {
+          filter.process(frame);
+          frame.hands = [];
+          filter.process(frame);
+        })
+
+        it("fires a stopped event the hold was started", function() {
+          expect(callback.lastCall.args[0].state).to.equal("stop");
+        })
+
+        it("includes no position", function() {
+          expect(callback.lastCall.args[0].position).to.be(null)
+        })
+
+        it("clears the tracked hold", function() {
+          // see if after a hold stop, we trigger a hold start at the new
+          // position, not an update
+          frame.hands = [hand];
+          filter.process(frame);
+          var gesture = callback.lastCall.args[0];
+          expect(gesture.state).to.equal("start");
+          expect(gesture.position).to.eql(hand.palmPosition);
         })
       })
     })
   })
-
 })

--- a/test/filter/hold_test.js
+++ b/test/filter/hold_test.js
@@ -1,0 +1,197 @@
+var expect = require('expect.js');
+var sinon = require('sinon')
+var BlueGel = require("../../lib/bluegel")
+var HoldFilter = BlueGel.Filter.types.gesture;
+var Analysis = BlueGel.Analysis;
+
+var callback = function(gesture) {
+  return gesture;
+}
+
+describe("Hold filter", function() {
+  var options, callback, filter, frame, hand, clock;
+
+  beforeEach(function() {
+    options = {
+      type: "hold",
+      maximumVelocity: 6,
+      maximumMovement: 8
+    };
+
+    callback = sinon.spy();
+    filter = new HoldFilter(options, callback);
+    hand = {
+      id: Math.random(),
+      position: [1, 2, 3],
+      palmVelocity: [0.5, 0.3, 0.4]
+    }
+
+    frame = {
+      hands: [hand]
+    }
+
+    clock = sinon.useFakeTimers();
+  })
+
+  afterEach(function() {
+    clock.restore();
+  })
+
+  describe("process", function() {
+    describe("if all requirements pass", function() {
+      beforeEach(function() {
+        filter.process(frame);
+      })
+
+      describe("the callback", function() {
+        var gesture;
+        beforeEach(function() {
+          gesture = callback.firstArgs[0];
+        })
+
+        it("calls the callback if all requirements pass", function() {
+          expect(callback.called).to.be(true);
+        })
+
+        it("includes the hand of the gesture", function() {
+          expect(gesture).to.have.property("handIds", [hand]);
+        })
+
+        it("includes no fingers", function() {
+          expect(gesture).to.have.property("pointableIds", []);
+        })
+
+        it("sets the type appropriately", function() {
+          expect(gesture.type).to.be("hold");
+        })
+
+        it("includes other gesture properties", function() {
+          var properties = ["type", "state", "position", "startPosition", "duration", "id"];
+          for (var i = 0; i < properties.length; i++) {
+            expect(gesture).to.have.property(properties[i]);
+          }
+        })
+      })
+
+      describe("if no hold is being tracked", function() {
+        it("starts a hold if there is none", function() {
+          filter.process(frame);
+          expect(callback.firstCall.args[0].state).to.equal("start");
+        })
+      })
+
+      describe("if there's already a hold", function() {
+        beforeEach(function() {
+          filter.process(frame);
+        })
+
+        it("sends an update", function() {
+          filter.process(frame);
+          expect(callback.callCount).to.be(2);
+          expect(gesture.state).to.equal("update");
+        })
+
+        it("updates the position", function() {
+          var originalLocation = frame.position;
+          frame.position = [
+            originalLocation[0] + 0.1,
+            originalLocation[1] + 0.1,
+            originalLocation[2] + 0.1
+          ];
+          var gesture = callback.lastCall.args[0];
+          expect(gesture.startPosition).to.eql(originalLocation);
+          expect(gesture.position).to.eql(frame.position);
+        })
+
+        it("updates the duration", function() {
+          filter.process(frame);
+          var ticks = 3;
+          clock.tick(3);
+          filter.process(frame);
+          expect(callback.lastCall.args[0].duration).to.equal(3);
+        })
+      })
+    })
+
+    describe("if velocity fails", function() {
+      describe("if no hold is being tracked", function() {
+        beforeEach(function() {
+          frame.velocity = [100, 100, 100];
+        })
+
+        it("doesn't start a gesture if there is none", function() {
+          filter.process(frame);
+          expect(callback.called).to.be(false);
+        })
+
+        it("also catches negative velocities", function() {
+          frame.velocity = [-100, 0, 0];
+          filter.process(frame);
+          expect(callback.called).to.be(false);
+        })
+      })
+
+      describe("if a hold is being tracked", function() {
+        beforeEach(function() {
+          frame.process(frame);
+          frame.velocity = [100, 100, 100];
+        })
+
+        it("fires a stopped event the hold was started", function() {
+          filter.process(frame);
+          expect(callback.lastCall.args[0].state).to.equal("stop");
+        })
+
+        it("clears the tracked hold", function() {
+          filter.process(frame);
+          frame.velocity = [0, 0, 0];
+          // see if after a hold stop, we trigger a hold start, not an update
+          filter.process(frame);
+          expect(callback.lastCall.args.state).to.equal("start");
+        })
+      })
+    })
+
+    describe("if position fails", function() {
+      describe("if no hold is being tracked", function() {
+        beforeEach(function() {
+          frame.position = [100, 100, 100];
+        })
+
+        it("doesn't start a gesture if there is none", function() {
+          filter.process(frame);
+          expect(callback.called).to.be(false);
+        })
+
+        it("also catches negative positions", function() {
+          frame.velocity = [-100, 0, 0];
+          filter.process(frame);
+          expect(callback.called).to.be(false);
+        })
+      })
+
+      describe("if a hold is being tracked", function() {
+        beforeEach(function() {
+          frame.process(frame);
+          frame.position = [100, 100, 100];
+        })
+
+        it("fires a stopped event the hold was started", function() {
+          filter.process(frame);
+          expect(callback.lastCall.args[0].state).to.equal("stop");
+        })
+
+        it("clears the tracked hold", function() {
+          filter.process(frame);
+          // see if after a hold stop, we trigger a hold start at the new
+          // position, not an update
+          filter.process(frame);
+          var gesture = callback.lastCall.args;
+          expect(gesture.state).to.equal("start");
+          expect(gesture.position).to.eql(frame.position);
+        })
+      })
+    })
+  })
+
+})


### PR DESCRIPTION
This pull request adds Holds, BlueGel's first synthetic gesture! Hold tracks a hand held in place for a specified amount of time; this is useful for menu items (if you watch the position) and can be useful as a trigger mechanism (for instance, to prevent inadvertent gestures). The minimum duration and allowed movement (measured either in movement through space or in hand velocity) are configurable.

Holds can be listened to like any other gesture:

``` js
var filter = new BlueGel.Filter();
filter.on("hold", options, callback);
```

I'll shortly integrate this in the LeapNoise demo app.
